### PR TITLE
Audit changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "solidity.compileUsingRemoteVersion": "v0.7.5+commit.eb77ed08"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "solidity.compileUsingRemoteVersion": "v0.7.5+commit.eb77ed08"
-}

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -507,7 +507,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
 
     function deposit() public payable nonReentrant whenNotPaused {
         // input is whole, not / 1e18 , i.e. in 1 = 1 eth send when from etherscan
-        uint256 value = uint256(msg.value);
+        uint256 value = msg.value;
 
         uint256 myAdminFee =
             adminFee.mul(value).mul(1e18).div(costPerValidator).div(1e18);

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.7.5;
 
-import {Address} from "@openzeppelin/contracts/utils/Address.sol"
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow
@@ -420,10 +420,19 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
     uint256 public adminFee;
     uint256 public numValidators;
     uint256 public costPerValidator;
-    uint256 public curValidatorShares;
-    uint256 public validatorsCreated;
-    uint256 public adminFeeTotal;
-    bool public disableWithdrawRefund;
+
+    // The validator shares created by this shared stake contract. 1 share costs >= 1 eth
+    uint256 public curValidatorShares; //initialized to 0
+
+    // The number of times the deposit to eth2 contract has been called to create validators
+    uint256 public validatorsCreated; //initialized to 0
+
+    // Total accrued admin fee
+    uint256 public adminFeeTotal; //initialized to 0
+
+    // Flash loan tokenomic protection in case of changes in admin fee with future lots
+    bool public disableWithdrawRefund; //initialized to false
+
     // Its hard to exactly hit the max deposit amount with small shares. this allows a small bit of overflow room
     // Eth in the buffer cannot be withdrawn by an admin, only by burning the underlying token via a user withdraw
     uint256 public buffer;
@@ -442,11 +451,6 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
 
         // Eth in the buffer cannot be withdrawn by an admin, only by burning the underlying token
         buffer = uint256(10).mul(1e18); // roughly equal to 10 eth.
-
-        curValidatorShares = 0; // The validator shares created by this shared stake contract. 1 share costs >= 1 eth
-        validatorsCreated = 0; // The number of times the deposit to eth2 contract has been called to create validators
-        adminFeeTotal = 0; // Total accrued admin fee
-        disableWithdrawRefund = false; // Flash loan tokenomic protection in case of changes in admin fee with future lots
 
         BETHTokenAddress = _BETHTokenAddress;
         BETHToken = IBETH(BETHTokenAddress);

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -412,7 +412,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
     using SafeMath for uint256;
     using SafeMath for uint256;
     /* ========== STATE VARIABLES ========== */
-    address public mainnetDepositContractAddress =
+    address public constant mainnetDepositContractAddress =
         0x00000000219ab540356cBB839Cbe05303d7705Fa;
 
     IDepositContract depositContract;

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.7.5;
 
+import {Address} from "@openzeppelin/contracts/utils/Address.sol"
+
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow
  * checks.
@@ -551,7 +553,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
         adminFeeTotal = adminFeeTotal.sub(valBeforeAdmin.sub(amount));
         BETHToken.burn(msg.sender, amount);
         address payable sender = msg.sender;
-        sender.transfer(valBeforeAdmin);
+        sender.sendValue(valBeforeAdmin);
     }
 
     // migration function to accept old monies and copy over state
@@ -636,7 +638,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
             amount <= adminFeeTotal,
             "Eth2Staker:withdrawAdminFee: More than adminFeeTotal cannot be withdrawn"
         );
-        sender.transfer(amount);
+        sender.sendValue(amount);
         adminFeeTotal = adminFeeTotal.sub(amount);
     }
 }

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -415,7 +415,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
     address public constant mainnetDepositContractAddress =
         0x00000000219ab540356cBB839Cbe05303d7705Fa;
 
-    IDepositContract depositContract;
+    IDepositContract private depositContract;
 
     uint256 public adminFee;
     uint256 public numValidators;
@@ -438,7 +438,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
     bool public disableWithdrawRefund; //initialized to false
 
     address public BETHTokenAddress;
-    IBETH BETHToken;
+    IBETH private BETHToken;
 
     constructor(
         uint256 _numValidators,

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -537,7 +537,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
         uint256 value = msg.value;
 
         uint256 myAdminFee =
-            adminFee.mul(value).mul(1e18).div(costPerValidator).div(1e18);
+            adminFee.mul(value).mul(1e18).div(32).div(1e18);
         uint256 valMinusAdmin = value.sub(myAdminFee);
         uint256 newShareTotal = curValidatorShares.add(valMinusAdmin);
 
@@ -586,13 +586,13 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
     // migration function to accept old monies and copy over state
     // users should not use this as it just donates the money without minting veth or tracking donations
     function donate(uint256 shares) external payable nonReentrant {
-        this.migrateShares(shares);
+
     }
 
     // OWNER ONLY FUNCTIONS
 
     // Used to migrate state over to new contract
-    function migrateShares(uint256 shares) external payable onlyOwner nonReentrant {
+    function migrateShares(uint256 shares) external onlyOwner nonReentrant {
         curValidatorShares = shares;
     }
 

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -430,12 +430,13 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
     // Total accrued admin fee
     uint256 public adminFeeTotal; //initialized to 0
 
-    // Flash loan tokenomic protection in case of changes in admin fee with future lots
-    bool public disableWithdrawRefund; //initialized to false
-
     // Its hard to exactly hit the max deposit amount with small shares. this allows a small bit of overflow room
     // Eth in the buffer cannot be withdrawn by an admin, only by burning the underlying token via a user withdraw
     uint256 public buffer;
+
+    // Flash loan tokenomic protection in case of changes in admin fee with future lots
+    bool public disableWithdrawRefund; //initialized to false
+
     address public BETHTokenAddress;
     IBETH BETHToken;
 

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -577,13 +577,15 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
             "Eth2Staker:depositToEth2: Not enough balance"
         ); //need at least 32 ETH
 
+        validatorsCreated = validatorsCreated.add(1);
+
         depositContract.deposit{value: amount}(
             pubkey,
             withdrawal_credentials,
             signature,
             deposit_data_root
         );
-        validatorsCreated = validatorsCreated.add(1);
+        
     }
 
     function setNumValidators(uint256 _numValidators) external onlyOwner {
@@ -638,7 +640,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
             amount <= adminFeeTotal,
             "Eth2Staker:withdrawAdminFee: More than adminFeeTotal cannot be withdrawn"
         );
-        sender.sendValue(amount);
         adminFeeTotal = adminFeeTotal.sub(amount);
+        sender.sendValue(amount);
     }
 }

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -1,6 +1,30 @@
 pragma solidity 0.7.5;
 
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+library Address {
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+}
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow
@@ -408,7 +432,7 @@ contract ReentrancyGuard {
     }
 }
 
-contract SharedDeposit is Pausable, ReentrancyGuard {
+contract SharedDeposit is Pausable, ReentrancyGuard, Address {
     using SafeMath for uint256;
     using SafeMath for uint256;
     /* ========== STATE VARIABLES ========== */

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -540,7 +540,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
         );
         require(
             address(this).balance > amount,
-            "Eth2Staker:withdraw:not enough balancce in contract"
+            "Eth2Staker:withdraw:Not enough balance in contract"
         );
         require(
             BETHToken.balanceOf(msg.sender) >= amount,
@@ -608,6 +608,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
         onlyOwner
         nonReentrant
     {
+        require(minter_ != address(0), "Minter cannot be zero address");
         BETHToken.setMinter(minter_);
 
         uint256 amount = address(this).balance;

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -589,6 +589,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
     }
 
     function setNumValidators(uint256 _numValidators) external onlyOwner {
+        require(_numValidators != 0, "Minimum 1 validator");
         numValidators = _numValidators;
     }
 

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -530,7 +530,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
                     adminFee.mul(1e18).div(costPerValidator)
                 )
             );
-        if (disableWithdrawRefund == true) {
+        if (disableWithdrawRefund) {
             valBeforeAdmin = amount;
         }
         uint256 newShareTotal = curValidatorShares.sub(amount);

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -498,7 +498,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard {
         return validatorLimitReached && balanceEnough;
     }
 
-    function maxValidatorShares() external view returns (uint256) {
+    function maxValidatorShares() public view returns (uint256) {
         return uint256(32).mul(1e18).mul(numValidators);
     }
 

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -564,11 +564,7 @@ contract SharedDeposit is Pausable, ReentrancyGuard, Address {
             newShareTotal <= buffer.add(maxValidatorShares()),
             "Eth2Staker:withdraw:Amount too large, not enough validators supplied"
         );
-
-        require(
-            newShareTotal >= 0,
-            "Eth2Staker:withdraw:Amount too small, not enough validators left"
-        );
+        
         require(
             address(this).balance > amount,
             "Eth2Staker:withdraw:Not enough balance in contract"
@@ -658,10 +654,6 @@ contract SharedDeposit is Pausable, ReentrancyGuard, Address {
     }
 
     function withdrawAdminFee(uint256 amount) external onlyOwner nonReentrant {
-        require(
-            validatorsCreated >= 0,
-            "Eth2Staker:withdrawAdminFee: No validators created. Admins cannot withdraw without creation"
-        );
         address payable sender = msg.sender;
         if (amount == 0) {
             amount = adminFeeTotal;

--- a/Minter_v1.0.1.sol
+++ b/Minter_v1.0.1.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.7.5;
+pragma solidity 0.7.5;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 

--- a/SmartTimelock.sol
+++ b/SmartTimelock.sol
@@ -87,7 +87,7 @@ abstract contract TokenTimelock is Ownable {
 */
 
 contract SmartTimelock is TokenTimelock, Executor, ReentrancyGuard {
-    address internal _governor;
+    address internal immutable _governor;
     mapping(address => bool) internal _transferAllowed;
 
     constructor(

--- a/SmartVesting.sol
+++ b/SmartVesting.sol
@@ -179,7 +179,7 @@ abstract contract SingleTokenVestingNonRevocable is Ownable {
 */
 
 contract SmartVesting is SingleTokenVestingNonRevocable, Executor, ReentrancyGuard {
-    address internal _governor;
+    address internal immutable _governor;
     mapping(address => bool) internal _transferAllowed;
 
     constructor(

--- a/stakingPools.sol
+++ b/stakingPools.sol
@@ -669,11 +669,6 @@ contract StakingRewards is
         onlyRewardsDistribution
         updateReward(address(0))
     {
-        // handle the transfer of reward tokens via `transferFrom` to reduce the number
-        // of transactions required and ensure correctness of the reward amount
-
-        rewardsToken.safeTransferFrom(rewardHolder, address(this), reward);
-
         if (block.timestamp >= periodFinish) {
             rewardRate = reward.div(rewardsDuration);
         } else {
@@ -684,7 +679,14 @@ contract StakingRewards is
 
         lastUpdateTime = block.timestamp;
         periodFinish = block.timestamp.add(rewardsDuration);
+
+        // handle the transfer of reward tokens via `transferFrom` to reduce the number
+        // of transactions required and ensure correctness of the reward amount
+
+        rewardsToken.safeTransferFrom(rewardHolder, address(this), reward);
+
         emit RewardAdded(reward);
+
     }
 
     // Added to support recovering LP Rewards from other systems such as BAL to be distributed to holders

--- a/stakingPools.sol
+++ b/stakingPools.sol
@@ -884,7 +884,7 @@ contract StakingRewardsFactory is Ownable {
     // In case of issues or incorrect calls or errors
     function refund(uint256 amount, address refundAddress) public onlyOwner {
         require(
-            IERC20(rewardsToken).transfer(refundAddress, amount),
+            IERC20(rewardsToken).safeTransfer(refundAddress, amount),
             "StakingRewardsFactory::notifyRewardAmount: transfer failed"
         );
     }

--- a/stakingPools.sol
+++ b/stakingPools.sol
@@ -814,6 +814,8 @@ contract Ownable {
 }
 
 contract StakingRewardsFactory is Ownable {
+    using SafeERC20 for IERC20;
+
     // immutables
     address public rewardsToken;
     uint256 public stakingRewardsGenesis;
@@ -883,7 +885,7 @@ contract StakingRewardsFactory is Ownable {
     // Fallback function to return money to reward distributer via pool deployer
     // In case of issues or incorrect calls or errors
     function refund(uint256 amount, address refundAddress) public onlyOwner {
-        require(rewardsToken.balanceOf(address(this)) >= amount, "StakingRewardsFactory::refund: Not enough tokens");
+        require(IERC20(rewardsToken).balanceOf(address(this)) >= amount, "StakingRewardsFactory::refund: Not enough tokens");
         IERC20(rewardsToken).safeTransfer(refundAddress, amount);
     }
 

--- a/stakingPools.sol
+++ b/stakingPools.sol
@@ -883,10 +883,8 @@ contract StakingRewardsFactory is Ownable {
     // Fallback function to return money to reward distributer via pool deployer
     // In case of issues or incorrect calls or errors
     function refund(uint256 amount, address refundAddress) public onlyOwner {
-        require(
-            IERC20(rewardsToken).safeTransfer(refundAddress, amount),
-            "StakingRewardsFactory::notifyRewardAmount: transfer failed"
-        );
+        require(rewardsToken.balanceOf(address(this)) > amount, "StakingRewardsFactory::refund: Not enough tokens");
+        IERC20(rewardsToken).safeTransfer(refundAddress, amount);
     }
 
     ///// permissionless functions

--- a/stakingPools.sol
+++ b/stakingPools.sol
@@ -883,7 +883,7 @@ contract StakingRewardsFactory is Ownable {
     // Fallback function to return money to reward distributer via pool deployer
     // In case of issues or incorrect calls or errors
     function refund(uint256 amount, address refundAddress) public onlyOwner {
-        require(rewardsToken.balanceOf(address(this)) > amount, "StakingRewardsFactory::refund: Not enough tokens");
+        require(rewardsToken.balanceOf(address(this)) >= amount, "StakingRewardsFactory::refund: Not enough tokens");
         IERC20(rewardsToken).safeTransfer(refundAddress, amount);
     }
 

--- a/vEth2.sol
+++ b/vEth2.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.7.5;
 pragma experimental ABIEncoderV2;
 
+// SPDX-License-Identifier: MIT
+
 // From https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/math/Math.sol
 // Subject to the MIT license.
 


### PR DESCRIPTION
I have completed all but 2 of the changes for #10 

The 2 remaining changes may need some discussion on how to resolve.

1. MIN-01M: The donate() function directly updates the state of the contract, namely the
curValidatorShares state variable, yet it publicly accessible and does not restrict the input
values.
2. VET-01M: The minters of the system can arbitrarily burn tokens.

> vEth2 contract is not upgradeable so this may not be able to be changed.